### PR TITLE
Fixed linking for terms

### DIFF
--- a/src/components/Navbars/Sidebars/right.tsx
+++ b/src/components/Navbars/Sidebars/right.tsx
@@ -218,7 +218,7 @@ export function SideBarRight(props:  {
                </Show>
               <div class="flex flex-col gap-5 mt-2 p-2 text-sm">
                 <li class="flex flex-row gap-5">
-                  <a class="cursor-pointer hover:underline">
+                  <a class="cursor-pointer hover:underline" href="/information/terms.pdf">
                     Terms of service
                   </a>
                   <a


### PR DESCRIPTION
Href was missing populated the field with the file for accessing, postlys terms of service.